### PR TITLE
First fixes for rop2.py

### DIFF
--- a/rop2.py
+++ b/rop2.py
@@ -14886,7 +14886,7 @@ def getBaseDir(filename=None, alt=None):
 	if ".exe" in filename:
 		filename =filename.replace(".exe", "")
 	base=os.getcwd()
-	baseDir  = os.path.join(base, filename, filename)
+	baseDir  = os.path.join(base, filename)
 	if not os.path.isdir(baseDir):
 		# print("Creating..")
 		os.makedirs(baseDir)
@@ -15224,7 +15224,7 @@ def uiShowBadBytes():
 	text +=mag+"  Find Bad Bytes in Offsets: \t\t\t\t {}\n".format(togBadOf)
 	text +="  \tOffsets include virtual address. This cannot be disabled. \t\t{}\n".format("")
 	text +=mag+"  Find Bad Bytes in ImageBase + VirtualAddress + Offset: {}\n".format(togBadIm)
-	text +=mag+"  Default ImageBase: {}\t VirtualAddress: {}\n".format(cya+hex(pe[n].ImageBase)+mag, cya+hex(pe[n].VirtualAdd)+mag)
+	text +=mag+"  Default ImageBase: {}\t VirtualAddress: {}\n".format(cya+hex(pe[n].imageBase)+mag, cya+hex(pe[n].VirtualAdd)+mag)
 
 	text +=mag+"  Current Bad Bytes: {}\n\n".format(cya+curBadBytes+res)
 	


### PR DESCRIPTION
1)
line: 14889
was: os.path.join(base, filename, filename)
now: os.path.join(base, filename)
reason: I believe the original idea was to make a directory named the same as the file and place the results of the analyzed file into that folder. However, in practice, the result is the following error:
```
File "<frozen os>", line 225, in makedirs
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\path\\to\\file\\filename\\filename'.
```
The proposed change relieves this error by instead placing the generated results of an analyzed file within the same directory as that file.

2)
line: 15227
was: pe[n].ImageBase 
now: pe[n].imageBase
reason: Upon entering the menu option `b -  Set Bad bytes / Bad chars and ImageBase.`, the original line caused the error:
```
AttributeError: 'PEInfo' object has no attribute 'ImageBase. Did you mean: 'imageBase'?'
```
After replacing the capitol 'i' with a lowercase one, the error was resolved.

****UPDATE****: Additional testing just showed that change 1) causes a file conflict. I can resolve by changing the mkdirs function. Please dismiss this pull request and I'll plan to submit one later after those changes.
